### PR TITLE
Remove card styling from Hobbies section

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,17 +303,15 @@
     </div>
   </section>
 
-  <section id="hobbies" class="py-16 px-4">
-  <div class="card max-w-3xl mx-auto">
-    <h2 class="text-2xl font-bold mb-4 text-gray-900 dark:text-gray-100">Hobbies & Passions</h2>
-    <ul class="list-disc list-inside space-y-2 text-gray-800 dark:text-gray-200">
+  <section id="hobbies">
+    <h2 class="text-2xl font-bold border-b pb-2 mb-4">Hobbies & Passions</h2>
+    <ul class="list-disc list-inside space-y-1 text-sm text-gray-700">
       <li>🏋️ Gym & Fitness</li>
       <li>🌊 Swimming & Sauna recovery rituals</li>
       <li>♟ Chess & Cybersecurity (ITIL, Power BI... working on CCNA)</li>
       <li>👨‍👩‍👧 Family & travel — soon: 🇩🇰 Copenhagen with the crew</li>
     </ul>
-  </div>
-</section>
+  </section>
 
 
   <!-- Contact Section -->


### PR DESCRIPTION
## Summary
- remove the div with `card` classes wrapping the Hobbies section
- update heading and list classes so the section matches the plain text style

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_683a9f3ecfc8832e958c10c2b9ffdb5d