### PR TITLE
Fix dark text for hobbies list

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,7 +305,7 @@
 
   <section id="hobbies">
     <h2 class="text-2xl font-bold border-b pb-2 mb-4">Hobbies & Passions</h2>
-    <ul class="list-disc list-inside space-y-1 text-sm text-gray-700">
+    <ul class="list-disc list-inside space-y-1 text-sm text-gray-700 dark:text-gray-100">
       <li>🏋️ Gym & Fitness</li>
       <li>🌊 Swimming & Sauna recovery rituals</li>
       <li>♟ Chess & Cybersecurity (ITIL, Power BI... working on CCNA)</li>


### PR DESCRIPTION
## Summary
- ensure the hobbies list text uses `dark:text-gray-100` so the text shows in white in dark mode

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_683aa2c26ee0832eb383c29ea2428192