### PR TITLE
Remove global link color override

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,8 +41,6 @@
     #theme-icon { transition: transform 0.5s ease; }
     #theme-icon.rotate { transform: rotate(180deg); }
     * { transition: background-color 0.5s ease, color 0.5s ease, border-color 0.5s ease; }
-    a { color: #2563eb; }
-    .dark a { color: #60a5fa; }
     .card {
       background-color: #ffffff;
       color: #1f2937;


### PR DESCRIPTION
## Summary
- remove the global link color styling

## Testing
- `grep -n "a {" -n index.html`


------
https://chatgpt.com/codex/tasks/task_b_683aa3dd7508832ebce6e0915639d466